### PR TITLE
feat: NYT Cookie Validation

### DIFF
--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -13,4 +13,3 @@ services:
       - ${NYT_COOKIES_PATH}:/crosswords/cookies.nyt.txt
       # To allow for changing .env without restarting the container
       - ./.env:/crosswords/.env
-    restart: unless-stopped

--- a/download-crossword.sh
+++ b/download-crossword.sh
@@ -160,10 +160,15 @@ function validate_flag_composition() {
 }
 
 function refresh_session_token() {
-    echo 'Refreshing cookies to ensure they will not expire...'
+    echo 'Checking NYT cookies are present...'
     local nyt_refresh_url='https://a.nytimes.com/svc/nyt/data-layer'
 
     local cookies=$(curl --silent --show-error --cookie-jar - -o /dev/null -b "${COOKIES_FILE_INTERNAL_PATH}" "${nyt_refresh_url}")
+    local is_valid_session=$(printf '%s\n' "$cookies" | grep 'NYT-S' && echo true || echo false)
+    test "${is_valid_session}" = "false" \
+        && echo "Invalid NYT cookies. Try obtaining your cookies again." \
+        && exit 1 \
+        || echo "Validated NYT cookies. Refreshing to ensure they will not expire..."
     printf '%s\n' "$cookies" > $COOKIES_FILE_INTERNAL_PATH
 
     echo 'Cookies refreshed.'


### PR DESCRIPTION
Let's make sure to exit and make the user aware that cookies are misconfigured before proceeding w/ cookie refresh or downloading of crosswords.