### PR TITLE
fix: Daily now sends whatever the current day is

### DIFF
--- a/main.sh
+++ b/main.sh
@@ -48,7 +48,7 @@ wait_until_send_time() {
 #### BEGIN MAIN EXECUTION
 
 # Initial download
-. ${SCRIPT_PATH}/download-crossword.sh ${CROSSWORD_COMMAND_LINE_ARGUMENTS}
+${SCRIPT_PATH}/download-crossword.sh ${CROSSWORD_COMMAND_LINE_ARGUMENTS}
 
 # Daily crossword sending
 while true; do
@@ -59,5 +59,5 @@ while true; do
 
   # Source .env to detect any changes to command-line arguments
   source ${SCRIPT_PATH}/.env
-  . ${SCRIPT_PATH}/download-crossword.sh ${CROSSWORD_COMMAND_LINE_ARGUMENTS}
+  ${SCRIPT_PATH}/download-crossword.sh ${CROSSWORD_COMMAND_LINE_ARGUMENTS}
 done


### PR DESCRIPTION
A bug in the restarter code was causing the daily sent crossword to always be the same day that the container was spunup. This is because the `download-crossword.sh` script was being sourced....instead, it should have been simply executed.
